### PR TITLE
fix(extractor/notes, yfm-lexer): explicit title

### DIFF
--- a/extractor/transformers/note.js
+++ b/extractor/transformers/note.js
@@ -1,5 +1,5 @@
-/* eslint-disable no-return-assign */
-const {map, equals, cond, always, compose, identity} = require('ramda');
+/* eslint-disable no-return-assign, no-shadow */
+const {map, equals, cond, always, compose, identity, invoker, tap} = require('ramda');
 const {notNil} = require('../../common/predicates');
 const {
     token: {typeLens},
@@ -18,12 +18,19 @@ const open = (token) => (noteTitle = title(token)) && null;
 
 const inside = (token) => noteTitle.children.push(token) && null;
 
+const attrGet = invoker(1, 'attrGet');
+
 const close = () => {
-    const merged = noteTitle.explicit ? noteTitle : null;
+    const effect = tap(() => (noteTitle = null));
 
-    noteTitle = null;
+    const title = cond([
+        [attrGet('yfm2xliff-explicit'), identity],
+        [always(true), always(null)],
+    ]);
 
-    return merged;
+    const go = compose(effect, title);
+
+    return go(noteTitle);
 };
 
 const transform = cond([

--- a/yfm-transform-fork/plugins/notes.js
+++ b/yfm-transform-fork/plugins/notes.js
@@ -86,8 +86,10 @@ function notes(md, {lang, path: optPath, log}) {
                 const strongClose = new state.Token('strong_close', 'strong', -1);
                 const titleClose = new state.Token('yfm_note_title_close', 'p', -1);
 
+                if (match[2]) {
+                    titleOpen.attrSet('yfm2xliff-explicit', 'true');
+                }
                 titleOpen.block = true;
-                titleOpen.explicit = match[2];
                 titleClose.block = true;
                 inlineText.content = match[2] === undefined ? getTitle(type, lang) : match[2];
                 inline.children = [strongOpen, inlineText, strongClose];


### PR DESCRIPTION
change attribute naming

refactor attribute check inside the extractor